### PR TITLE
Upgrade SOAPUI to 5.2.0

### DIFF
--- a/soapui/soapui.nuspec
+++ b/soapui/soapui.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>soapui</id>
-    <version>5.0.0.1</version>
+    <version>5.2.0</version>
     <title>SoapUI</title>
     <authors>SmartBear Software</authors>
     <owners>SmartBear Software</owners>

--- a/soapui/tools/chocolateyInstall.ps1
+++ b/soapui/tools/chocolateyInstall.ps1
@@ -1,15 +1,7 @@
 $packageName = 'soapui' # arbitrary name for the package, used in messages
 $fileType = 'exe'
-$url = 'http://downloads.sourceforge.net/project/soapui/soapui/5.0.0/SoapUI-x32-5.0.0.exe?r=&ts=1403616764&use_mirror=iweb'
-try
-{
-	#Install-ChocolateyPackage $packageName $fileType $silentArgs $url
-    Install-ChocolateyPackage $packageName $fileType '-q' $url
+$url = 'http://downloads.sourceforge.net/project/soapui/soapui/5.2.0/SoapUI-x32-5.2.0.exe?r=&ts=1438411788&use_mirror=iweb'	
+$url64bit =	'http://downloads.sourceforge.net/project/soapui/soapui/5.2.0/SoapUI-x64-5.2.0.exe?r=&ts=1438410362&use_mirror=iweb'	
 
-    Write-ChocolateySuccess $packageName
-}
-catch
-{
-    Write-ChocolateyFailure $packageName "$($_.Exception.Message)"
-    throw 
-}
+#Install-ChocolateyPackage $packageName $fileType $silentArgs $url $url64bit
+Install-ChocolateyPackage $packageName $fileType '-q' $url $url64bit


### PR DESCRIPTION
- Allow for both 32-bit and 64-bit installs.
- Remove commands that are now obsolete in Chocolatey 0.9.9
